### PR TITLE
새로운 동영상을 볼 때 상태변화때문에 순간적인 동영상 소리들리는 현상 제거

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -59,24 +59,31 @@ const Player = React.memo(({ music }) => {
     clearInterval(timeTrash.current);
   }, [timeTrash, state]);
 
-  const handlePlaying = useCallback((e) => {
-    clearInterval(timeTrash.current);
+  const handleStateChange = useCallback((e) => {
     if (start) {
       e.target.seekTo(0);
-      return setState({
+      setState({
         ...state,
         start: false,
         currentTime: 0,
-        endTime: e.target.getDuration(),
       });
     }
+  }, [state]);
 
+  const handlePlaying = useCallback((e) => {
+    clearInterval(timeTrash.current);
+    setState((preveState) => ({
+      ...preveState,
+      endTime: e.target.getDuration(),
+    }));
     timeTrash.current = setInterval(() => {
       setState((preveState) => ({
         ...preveState,
         currentTime: e.target.getCurrentTime(),
+        endTime: e.target.getDuration(),
       }));
     }, 1000, start);
+
     return timeTrash;
   }, [timeTrash, start]);
 
@@ -90,8 +97,9 @@ const Player = React.memo(({ music }) => {
       <Youtube
         autoplay
         ref={player}
-        onEnd={handleEndPlay}
+        onStateChange={handleStateChange}
         onPlaying={handlePlaying}
+        onEnd={handleEndPlay}
         startSeconds={Number(currentTime)}
         video={videoId}
         paused={paused}


### PR DESCRIPTION
새로운 동영상을 틀 때 새로운 동영상을 틀었다는 것을 인지하는 순간이 Youtube Component의 onPlaying에서 인지하기에
순간적인 동영상소리가 들렸습니다. 하지만 onStateChange에서 인지하게 하여 이러한 버그를 제거했습니다.