### PR TITLE
Player최적화

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -15,7 +15,7 @@ const Player = React.memo(({ music }) => {
   const [state, setState] = useState({
     paused: false,
     start: true,
-    endTime: 100,
+    endTime: 0,
     currentTime: 0,
   });
 
@@ -29,7 +29,7 @@ const Player = React.memo(({ music }) => {
     setState({
       paused: false,
       start: true,
-      endTime: 100,
+      endTime: 0,
       currentTime: 0,
     });
   }, [music.videoId]);
@@ -66,6 +66,7 @@ const Player = React.memo(({ music }) => {
         ...state,
         start: false,
         currentTime: 0,
+        endTime: e.target.getDuration(),
       });
     }
   }, [state]);
@@ -80,7 +81,6 @@ const Player = React.memo(({ music }) => {
       setState((preveState) => ({
         ...preveState,
         currentTime: e.target.getCurrentTime(),
-        endTime: e.target.getDuration(),
       }));
     }, 1000, start);
 
@@ -100,7 +100,6 @@ const Player = React.memo(({ music }) => {
         onStateChange={handleStateChange}
         onPlaying={handlePlaying}
         onEnd={handleEndPlay}
-        startSeconds={Number(currentTime)}
         video={videoId}
         paused={paused}
       />

--- a/src/components/__tests__/Player.test.jsx
+++ b/src/components/__tests__/Player.test.jsx
@@ -31,14 +31,14 @@ describe('Player', () => {
     expect(queryByText('PLAY')).toBeInTheDocument();
   });
 
-  it('STOP을 누르면 PLAY로 변경된다.2', () => {
-    const { queryByDisplayValue, queryByText } = renderPlayer();
+  it('input의 range를 바꾸면 이동한다.', () => {
+    const { queryByDisplayValue, queryAllByText } = renderPlayer();
     fireEvent.change(queryByDisplayValue('0'), {
       target: {
-        value: 52,
+        value: 0,
       },
     });
 
-    expect(queryByText('0:52')).toBeInTheDocument();
+    expect(queryAllByText('0:00')[0]).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
* 로직에 영향을 미치지 않는 필요없는 상태변화 제거
*  test코드때문에 손해보았던 UI를 위해 test코드 수정

 **_test코드에서 input의 range를 바꾸려면 range의 max가 0보다 큰 숫자여야했습니다.
 이것은 초기에 player가 로드되기 전까지의 UI를 이상하게 만듭니다. 따라서 test코드가 통과되는 것을 확인한 후 UI의 자연스러움을 위해 test코드를 수정했습니다._** 