### PR TITLE
playlist에서 다음 곡 과 이전 곡이 나오도록 기능 개선

### DIFF
--- a/src/components/SearchResult.jsx
+++ b/src/components/SearchResult.jsx
@@ -23,6 +23,7 @@ export default function SearchResult({ musics, onMoreClick, onListenClick }) {
         <div>
           {musics?.map((music) => (
             <Song
+              resultToken
               key={String(music.id.videoId)}
               music={music}
               onListenClick={onListenClick}

--- a/src/components/Song.jsx
+++ b/src/components/Song.jsx
@@ -49,7 +49,7 @@ const PlayButton = styled.div({
   },
 });
 
-export default function Song({ music, onListenClick }) {
+export default function Song({ resultToken, music, onListenClick }) {
   const {
     id: { videoId },
     snippet: {
@@ -61,8 +61,10 @@ export default function Song({ music, onListenClick }) {
   } = music;
 
   const handleClick = useCallback(() => {
-    onListenClick({ videoId, title, url });
-  }, [onListenClick, videoId, title, url]);
+    onListenClick({
+      resultToken, videoId, title, url,
+    });
+  }, [resultToken, onListenClick, videoId, title, url]);
 
   return (
     <Item onClick={handleClick}>

--- a/src/container/PlayerContainer.jsx
+++ b/src/container/PlayerContainer.jsx
@@ -4,27 +4,22 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import Player from '../components/Player';
 
-import { addPlaylistMusic, setPalyer } from '../redux/slice';
+import { addPlaylistMusic, setNextMusic, setPreviousMusic } from '../redux/slice';
 
-import { get, getNextMusic, getPreviousMusic } from '../services/utils';
+import { get } from '../services/utils';
 
 export default function PlayerContainer() {
   const dispatch = useDispatch();
 
   const music = useSelector(get('player'));
-  const musics = useSelector(get('musics'));
 
   const handleClickNext = useCallback(() => {
-    const nextMusic = getNextMusic(musics, music);
-
-    dispatch(setPalyer(nextMusic));
-  }, [musics, music]);
+    dispatch(setNextMusic(music));
+  }, [music, dispatch, setNextMusic]);
 
   const handleClickPrevious = useCallback(() => {
-    const previousMusic = getPreviousMusic(musics, music);
-
-    dispatch(setPalyer(previousMusic));
-  }, [musics, music]);
+    dispatch(setPreviousMusic(music));
+  }, [music, dispatch, setPreviousMusic]);
 
   const handleClickAddPlaylistMusic = useCallback(() => {
     dispatch(addPlaylistMusic(music));

--- a/src/container/PlaylistContainer.jsx
+++ b/src/container/PlaylistContainer.jsx
@@ -14,7 +14,7 @@ export default function PlaylistContainer() {
   const playlist = useSelector(get('playlist'));
 
   const handleClickListen = useCallback((music) => {
-    dispatch(setPalyer(music));
+    dispatch(setPalyer({ resultToken: 0, ...music }));
   }, [dispatch, setPalyer]);
 
   const handleClickDelete = useCallback((music) => {

--- a/src/container/SearchResultContainer.jsx
+++ b/src/container/SearchResultContainer.jsx
@@ -22,8 +22,12 @@ export default function SearchResultContainer({ keyword }) {
     dispatch(searchMoreMusic(keyword, nextPageToken));
   }, [dispatch, keyword, nextPageToken]);
 
-  const handleListenClick = useCallback(({ videoId, title, url }) => {
-    dispatch(setPalyer({ videoId, title, url }));
+  const handleListenClick = useCallback(({
+    resultToken, videoId, title, url,
+  }) => {
+    dispatch(setPalyer({
+      resultToken, videoId, title, url,
+    }));
   }, [dispatch]);
 
   return (

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { fetchYouTubeMusics } from '../services/api';
 
 import { saveItem } from '../services/storage';
+import { getNextMusic, getPreviousMusic } from '../services/utils';
 
 const { reducer, actions } = createSlice({
   name: 'application',
@@ -31,9 +32,9 @@ const { reducer, actions } = createSlice({
       musics: [...state.musics, ...items],
     }),
 
-    setPalyer: (state, { payload: { videoId, title, url } }) => ({
+    setPalyer: (state, { payload: playerInfo }) => ({
       ...state,
-      player: { videoId, title, url },
+      player: playerInfo,
     }),
 
     updatePlaylistMusic: (state, { payload: playlist }) => ({
@@ -70,6 +71,28 @@ export function searchMoreMusic(keyword, nextPageToken) {
     const response = await fetchYouTubeMusics(keyword, nextPageToken);
 
     dispatch(addResponse(response));
+  };
+}
+
+export function setPreviousMusic(music) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const { resultToken } = music;
+    const playlist = resultToken ? state.musics : state.playlist;
+    const previousMusic = getPreviousMusic(playlist, music);
+
+    dispatch(setPalyer({ resultToken, ...previousMusic }));
+  };
+}
+
+export function setNextMusic(music) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const { resultToken } = music;
+    const playlist = resultToken ? state.musics : state.playlist;
+    const nextMusic = getNextMusic(playlist, music);
+
+    dispatch(setPalyer({ resultToken, ...nextMusic }));
   };
 }
 

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -11,8 +11,10 @@ import reducer, {
   updatePlaylistMusic,
   searchMusic,
   searchMoreMusic,
-  deletePlaylistMusic,
+  setPreviousMusic,
+  setNextMusic,
   addPlaylistMusic,
+  deletePlaylistMusic,
 } from './slice';
 
 import music from '../../fixtures/music';
@@ -132,6 +134,46 @@ describe('slice', () => {
 
         const actions = store.getActions();
         expect(actions[0]).toEqual(addResponse([]));
+      });
+    });
+
+    describe('setPreviousMusic', () => {
+      it('Playlist의 이전 곡을 실행시킨다.', () => {
+        store = mockStore({ musics: musics.items });
+        store.dispatch(setPreviousMusic({ resultToken: 1, ...music }));
+
+        const actions = store.getActions();
+        const previousMusic = { resultToken: 1, ...filterMusicInfo(musics.items[1]) };
+        expect(actions[0]).toEqual(setPalyer(previousMusic));
+      });
+
+      it('SearchResult의 이전 곡을 실행시킨다.', () => {
+        store = mockStore({ playlist: musics.items.map((item) => filterMusicInfo(item)) });
+        store.dispatch(setPreviousMusic({ resultToken: 0, ...music }));
+
+        const actions = store.getActions();
+        const previousMusic = { resultToken: 0, ...filterMusicInfo(musics.items[1]) };
+        expect(actions[0]).toEqual(setPalyer(previousMusic));
+      });
+    });
+
+    describe('setNextMusic', () => {
+      it('Playlist의 다음 곡을 실행시킨다.', () => {
+        store = mockStore({ musics: musics.items });
+        store.dispatch(setNextMusic({ resultToken: 1, ...music }));
+
+        const actions = store.getActions();
+        const previousMusic = { resultToken: 1, ...filterMusicInfo(musics.items[1]) };
+        expect(actions[0]).toEqual(setPalyer(previousMusic));
+      });
+
+      it('SearchResult의 다음 곡을 실행시킨다.', () => {
+        store = mockStore({ playlist: musics.items.map((item) => filterMusicInfo(item)) });
+        store.dispatch(setNextMusic({ resultToken: 0, ...music }));
+
+        const actions = store.getActions();
+        const previousMusic = { resultToken: 0, ...filterMusicInfo(musics.items[1]) };
+        expect(actions[0]).toEqual(setPalyer(previousMusic));
       });
     });
 

--- a/src/services/__tests__/utils.test.js
+++ b/src/services/__tests__/utils.test.js
@@ -29,28 +29,68 @@ test('filterMusicInfo', () => {
   expect(filteredMusicInfo.videoId).toBe(music.videoId);
 });
 
-test('getPreviousMusic', () => {
-  const previousMusic = getPreviousMusic(musics.items, music);
+describe('getPreviousMusic', () => {
+  context('playlist일 경우', () => {
+    const playlist = musics.items.map((item) => filterMusicInfo(item));
 
-  expect(previousMusic.title).toBe(musics.items[1].snippet.title);
+    it('이전 노래를 반환한다.', () => {
+      const previousMusic = getPreviousMusic(playlist, filterMusicInfo(musics.items[1]));
+
+      expect(previousMusic.title).toBe(musics.items[0].snippet.title);
+    });
+
+    it('처음이라면 마지막 노래를 반환한다.', () => {
+      const previousMusic = getPreviousMusic(playlist, music);
+
+      expect(previousMusic.title).toBe(musics.items[1].snippet.title);
+    });
+  });
+
+  context('SearchResult일 경우', () => {
+    it('이전 노래를 반환한다.', () => {
+      const previousMusic = getPreviousMusic(musics.items, filterMusicInfo(musics.items[1]));
+
+      expect(previousMusic.title).toBe(musics.items[0].snippet.title);
+    });
+
+    it('처음이라면 마지막 노래를 반환한다.', () => {
+      const previousMusic = getPreviousMusic(musics.items, music);
+
+      expect(previousMusic.title).toBe(musics.items[1].snippet.title);
+    });
+  });
 });
 
-test('getPreviousMusic', () => {
-  const previousMusic = getPreviousMusic(musics.items, filterMusicInfo(musics.items[1]));
+describe('getNextMusic', () => {
+  context('playlist일 경우', () => {
+    const playlist = musics.items.map((item) => filterMusicInfo(item));
 
-  expect(previousMusic.title).toBe(musics.items[0].snippet.title);
-});
+    it('다음 노래를 반환한다.', () => {
+      const nextMusic = getNextMusic(playlist, music);
 
-test('getNextMusic', () => {
-  const nextMusic = getNextMusic(musics.items, music);
+      expect(nextMusic.title).toBe(musics.items[1].snippet.title);
+    });
 
-  expect(nextMusic.title).toBe(musics.items[1].snippet.title);
-});
+    it('마지막이라면 처음 노래를 반환한다.', () => {
+      const nextMusic = getNextMusic(playlist, filterMusicInfo(musics.items[1]));
 
-test('getNextMusic', () => {
-  const nextMusic = getNextMusic(musics.items, filterMusicInfo(musics.items[1]));
+      expect(nextMusic.title).toBe(musics.items[0].snippet.title);
+    });
+  });
 
-  expect(nextMusic.title).toBe(musics.items[0].snippet.title);
+  context('SearchResult일 경우', () => {
+    it('다음 노래를 반환한다.', () => {
+      const nextMusic = getNextMusic(musics.items, music);
+
+      expect(nextMusic.title).toBe(musics.items[1].snippet.title);
+    });
+
+    it('마지막이라면 처음 노래를 반환한다.', () => {
+      const nextMusic = getNextMusic(musics.items, filterMusicInfo(musics.items[1]));
+
+      expect(nextMusic.title).toBe(musics.items[0].snippet.title);
+    });
+  });
 });
 
 test('translateTime', () => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -17,6 +17,13 @@ export function filterMusicInfo(music) {
 }
 
 export function getPreviousMusic(musics, music) {
+  if (!musics[0].snippet) {
+    const musicIndex = musics.findIndex(({ videoId }) => music.videoId === videoId);
+    const previousMusic = musics[musicIndex ? musicIndex - 1 : musics.length - 1];
+
+    return previousMusic;
+  }
+
   const musicIndex = musics.findIndex(({ id: { videoId } }) => music.videoId === videoId);
   const previousMusic = musics[musicIndex ? musicIndex - 1 : musics.length - 1];
 
@@ -24,6 +31,13 @@ export function getPreviousMusic(musics, music) {
 }
 
 export function getNextMusic(musics, music) {
+  if (!musics[0].snippet) {
+    const musicIndex = musics.findIndex(({ videoId }) => music.videoId === videoId);
+    const nextMusic = musics[musicIndex === musics.length - 1 ? 0 : musicIndex + 1];
+
+    return nextMusic;
+  }
+
   const musicIndex = musics.findIndex(({ id: { videoId } }) => music.videoId === videoId);
   const nextMusic = musics[musicIndex === musics.length - 1 ? 0 : musicIndex + 1];
 


### PR DESCRIPTION
playlist의 곡과 searchResult의 곡을 구별해서 인지하여 각각의 환경에서 다음곡과 이전곡을 실행할 수 있게 했습니다.