### PR TITLE
player의 state중 App에서 관리해야할 state 분리

### DIFF
--- a/fixtures/playerInfo.js
+++ b/fixtures/playerInfo.js
@@ -1,0 +1,8 @@
+const playerInfo = {
+  playStyle: 0,
+  volume: 1,
+  mute: false,
+  suffle: false,
+};
+
+export default playerInfo;

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -13,11 +13,16 @@ const playStyles = ['순환 반복', '한곡 반복', '한곡 듣기'];
 
 const Player = React.memo(({
   music,
+  playerInfo,
   onClickNext,
   onClickPrevious,
   onClickAddPlaylistMusic,
+  onClickMute,
+  onClickVolume,
+  onClickPlayStyle,
 }) => {
   const { videoId, title, url } = music;
+  const { playStyle, mute, volume } = playerInfo;
 
   const player = useRef(null);
   const timeTrash = useRef(null);
@@ -25,26 +30,20 @@ const Player = React.memo(({
   const initialState = {
     paused: false,
     highLight: false,
-    mute: false,
     click: false,
-    volume: 1,
     start: true,
     endTime: 0,
     currentTime: 0,
-    playStyle: 0,
   };
 
   const [state, setState] = useState(initialState);
   const {
     paused,
     highLight,
-    mute,
-    volume,
     click,
     start,
     endTime,
     currentTime,
-    playStyle,
   } = state;
 
   useEffect(() => {
@@ -74,20 +73,6 @@ const Player = React.memo(({
   const handleClickHighLight = useCallback(() => {
     player.current.playerInstance?.seekTo(60);
   }, [player]);
-
-  const handleClickMuted = useCallback(() => {
-    setState({
-      ...state,
-      mute: !mute,
-    });
-  }, [state]);
-
-  const handleChangeVolume = useCallback((e) => {
-    setState({
-      ...state,
-      volume: Number(e.target.value),
-    });
-  }, [state]);
 
   const handleStateChange = useCallback((e) => {
     if (start) {
@@ -146,9 +131,9 @@ const Player = React.memo(({
     setState({ ...state, click: false });
   }, [state, click]);
 
-  const handleClickPlayStyle = useCallback(() => {
-    setState({ ...state, playStyle: playStyle < 2 ? playStyle + 1 : 0 });
-  }, [state, playStyle]);
+  const handleClickVolume = useCallback((e) => {
+    onClickVolume(Number(e.target.value));
+  }, [onClickVolume]);
 
   return (
     <>
@@ -204,7 +189,7 @@ const Player = React.memo(({
       />
       <button
         type="button"
-        onClick={handleClickMuted}
+        onClick={onClickMute}
       >
         {mute ? '음소거 해제' : '음소거'}
       </button>
@@ -214,11 +199,11 @@ const Player = React.memo(({
         min={0}
         max={1}
         step={0.01}
-        onChange={handleChangeVolume}
+        onChange={handleClickVolume}
       />
       <button
         type="button"
-        onClick={handleClickPlayStyle}
+        onClick={onClickPlayStyle}
       >
         {playStyles[Number(playStyle)]}
       </button>

--- a/src/components/__tests__/Player.test.jsx
+++ b/src/components/__tests__/Player.test.jsx
@@ -5,19 +5,27 @@ import { fireEvent, render } from '@testing-library/react';
 import Player from '../Player';
 
 import music from '../../../fixtures/music';
+import playerInfo from '../../../fixtures/playerInfo';
 
 describe('Player', () => {
   const handleClickNext = jest.fn();
   const handleClickPrevious = jest.fn();
   const handleClickAddPlaylistMusic = jest.fn();
+  const handleClickMute = jest.fn();
+  const handleClickVolume = jest.fn();
+  const handleClickPlayStyle = jest.fn();
 
   function renderPlayer() {
     return render(
       <Player
         music={music}
+        playerInfo={playerInfo}
         onClickNext={handleClickNext}
         onClickPrevious={handleClickPrevious}
         onClickAddPlaylistMusic={handleClickAddPlaylistMusic}
+        onClickMute={handleClickMute}
+        onClickVolume={handleClickVolume}
+        onClickPlayStyle={handleClickPlayStyle}
       />,
     );
   }
@@ -47,7 +55,7 @@ describe('Player', () => {
 
     expect(queryByText('음소거')).toBeInTheDocument();
     fireEvent.click(queryByText('음소거'));
-    expect(queryByText('음소거 해제')).toBeInTheDocument();
+    expect(handleClickMute).toBeCalled();
   });
 
   it('다음 노래 버튼를 누르면 handleClickNext가 실행된다.', () => {
@@ -85,7 +93,7 @@ describe('Player', () => {
     expect(queryAllByText('0:00')[0]).toBeInTheDocument();
   });
 
-  it('음량 input의 range를 바꾸면 이동한다.', () => {
+  it('음량 input의 range를 바꾸면 handleClickVolume이 실행된다.', () => {
     const { queryByDisplayValue } = renderPlayer();
     fireEvent.change(queryByDisplayValue('1'), {
       target: {
@@ -93,6 +101,13 @@ describe('Player', () => {
       },
     });
 
-    expect(queryByDisplayValue('0.5')).toBeInTheDocument();
+    expect(handleClickVolume).toBeCalled();
+  });
+
+  it('playStyle(한곡반복 등)버튼을 클릭하면 handleClickPlayStyle이 실행된다.', () => {
+    const { queryByText } = renderPlayer();
+    fireEvent.click(queryByText('순환 반복'));
+
+    expect(handleClickPlayStyle).toBeCalled();
   });
 });

--- a/src/container/PlayerContainer.jsx
+++ b/src/container/PlayerContainer.jsx
@@ -4,7 +4,14 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import Player from '../components/Player';
 
-import { addPlaylistMusic, setNextMusic, setPreviousMusic } from '../redux/slice';
+import {
+  addPlaylistMusic,
+  setNextMusic,
+  setPreviousMusic,
+  changePlayStyle,
+  toggleMute,
+  changeVolume,
+} from '../redux/slice';
 
 import { get } from '../services/utils';
 
@@ -12,6 +19,7 @@ export default function PlayerContainer() {
   const dispatch = useDispatch();
 
   const music = useSelector(get('player'));
+  const playerInfo = useSelector(get('playerInfo'));
 
   const handleClickNext = useCallback(() => {
     dispatch(setNextMusic(music));
@@ -25,6 +33,18 @@ export default function PlayerContainer() {
     dispatch(addPlaylistMusic(music));
   }, [music]);
 
+  const handleClickPlayStyle = useCallback(() => {
+    dispatch(changePlayStyle());
+  }, [dispatch]);
+
+  const handleClickMute = useCallback(() => {
+    dispatch(toggleMute());
+  }, [dispatch]);
+
+  const handleClickVolume = useCallback((volume) => {
+    dispatch(changeVolume(volume));
+  }, [dispatch]);
+
   if (!music?.videoId) {
     return (<></>);
   }
@@ -32,9 +52,13 @@ export default function PlayerContainer() {
   return (
     <Player
       music={music}
+      playerInfo={playerInfo}
       onClickNext={handleClickNext}
       onClickPrevious={handleClickPrevious}
       onClickAddPlaylistMusic={handleClickAddPlaylistMusic}
+      onClickMute={handleClickMute}
+      onClickVolume={handleClickVolume}
+      onClickPlayStyle={handleClickPlayStyle}
     />
   );
 }

--- a/src/container/__tests__/PlayerContainer.test.jsx
+++ b/src/container/__tests__/PlayerContainer.test.jsx
@@ -10,6 +10,7 @@ import PlayerContainer from '../PlayerContainer';
 
 import music from '../../../fixtures/music';
 import musics from '../../../fixtures/musics';
+import playerInfo from '../../../fixtures/playerInfo';
 
 describe('PlayerContainer', () => {
   const dispatch = jest.fn();
@@ -17,6 +18,7 @@ describe('PlayerContainer', () => {
   useDispatch.mockImplementation(() => dispatch);
   useSelector.mockImplementation((selector) => selector({
     player: given.music,
+    playerInfo,
     musics: musics.items,
   }));
 
@@ -66,6 +68,34 @@ describe('PlayerContainer', () => {
       const { queryByText } = renderPlayerContainer();
 
       fireEvent.click(queryByText('플레이 리스트에 추가'));
+
+      expect(dispatch).toBeCalled();
+    });
+
+    it('음소거 버튼을 누르면 dispatch가 실행된다.', () => {
+      const { queryByText } = renderPlayerContainer();
+
+      fireEvent.click(queryByText('음소거'));
+
+      expect(dispatch).toBeCalled();
+    });
+
+    it('음량을 바꾸면 dispatch가 실행된다.', () => {
+      const { queryByDisplayValue } = renderPlayerContainer();
+
+      fireEvent.change(queryByDisplayValue('1'), {
+        target: {
+          value: 0.5,
+        },
+      });
+
+      expect(dispatch).toBeCalled();
+    });
+
+    it('playStyle(한곡 반복 등)버튼을 누르면 dispatch가 실행된다.', () => {
+      const { queryByText } = renderPlayerContainer();
+
+      fireEvent.click(queryByText('순환 반복'));
 
       expect(dispatch).toBeCalled();
     });

--- a/src/pages/__tests__/PlayerPage.test.jsx
+++ b/src/pages/__tests__/PlayerPage.test.jsx
@@ -7,10 +7,12 @@ import { useSelector } from 'react-redux';
 import music from '../../../fixtures/music';
 
 import PlayerPage from '../PlayerPage';
+import playerInfo from '../../../fixtures/playerInfo';
 
 describe('PlayerPage', () => {
   useSelector.mockImplementation((selector) => selector({
     player: music,
+    playerInfo,
   }));
 
   beforeEach(() => jest.clearAllMocks());

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -13,6 +13,12 @@ const { reducer, actions } = createSlice({
     playlist: [],
     musics: [],
     player: {},
+    playerInfo: {
+      playStyle: 0,
+      volume: 1,
+      mute: false,
+      suffle: false,
+    },
   },
   reducers: {
     updateInput: (state, { payload: input }) => ({
@@ -37,6 +43,30 @@ const { reducer, actions } = createSlice({
       player: playerInfo,
     }),
 
+    changePlayStyle: (state) => ({
+      ...state,
+      playerInfo: {
+        ...state.playerInfo,
+        playStyle: state.playerInfo.playStyle < 2 ? state.playerInfo.playStyle + 1 : 0,
+      },
+    }),
+
+    toggleMute: (state) => ({
+      ...state,
+      playerInfo: {
+        ...state.playerInfo,
+        mute: !state.playerInfo.mute,
+      },
+    }),
+
+    changeVolume: (state, { payload: volume }) => ({
+      ...state,
+      playerInfo: {
+        ...state.playerInfo,
+        volume,
+      },
+    }),
+
     updatePlaylistMusic: (state, { payload: playlist }) => ({
       ...state,
       playlist,
@@ -54,6 +84,9 @@ export const {
   addResponse,
   setResponse,
   setPalyer,
+  changePlayStyle,
+  toggleMute,
+  changeVolume,
   updatePlaylistMusic,
   appendPlaylistMusic,
 } = actions;

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -15,6 +15,9 @@ import reducer, {
   setNextMusic,
   addPlaylistMusic,
   deletePlaylistMusic,
+  changePlayStyle,
+  toggleMute,
+  changeVolume,
 } from './slice';
 
 import music from '../../fixtures/music';
@@ -80,6 +83,35 @@ describe('slice', () => {
       const state = reducer(initialState, setPalyer(song));
 
       expect(state.player.videoId).toBe('VIDEO_ID');
+    });
+
+    it('changePlayStyle', () => {
+      const initialState = {
+        playerInfo: { playStyle: 1 },
+      };
+
+      const state = reducer(initialState, changePlayStyle());
+      expect(state.playerInfo.playStyle).toBe(2);
+      const nextState = reducer(state, changePlayStyle());
+      expect(nextState.playerInfo.playStyle).toBe(0);
+    });
+
+    it('toggleMute', () => {
+      const initialState = {
+        playerInfo: { mute: true },
+      };
+
+      const state = reducer(initialState, toggleMute());
+      expect(state.playerInfo.mute).toBe(false);
+    });
+
+    it('changeVolume', () => {
+      const initialState = {
+        playerInfo: { volume: 1 },
+      };
+
+      const state = reducer(initialState, changeVolume(0.5));
+      expect(state.playerInfo.volume).toBe(0.5);
     });
 
     it('updatePlaylistMusic', () => {


### PR DESCRIPTION
기존에는 player에서 독자적인 state를 관리했었습니다.(음량, 반복방식, 음소거, 셔플 등)
하지만 이렇게 하면 다음 곡으로 넘어갔을 때 음량과 playStyle 등 하나의 노래에 국한되지 않는 State가 초기화 되었습니다. 
따라서 그런 state를 App단에서 관리하도록 하여 State의 초기화 현상을 제거하였습니다.

가능해 진 것의 예) **음량을 0.5로 하고 다음 노래로 가면 다시 음량이 1이 됨 -> 계속 유지됨** 