### PR TITLE
플레이리스트 셔플 기능 구현

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -20,9 +20,15 @@ const Player = React.memo(({
   onClickMute,
   onClickVolume,
   onClickPlayStyle,
+  onClickSuffle,
 }) => {
   const { videoId, title, url } = music;
-  const { playStyle, mute, volume } = playerInfo;
+  const {
+    playStyle,
+    isMute,
+    volume,
+    isSuffle,
+  } = playerInfo;
 
   const player = useRef(null);
   const timeTrash = useRef(null);
@@ -147,7 +153,7 @@ const Player = React.memo(({
         ref={player}
         video={videoId}
         paused={paused}
-        muted={mute}
+        muted={isMute}
         volume={volume}
         onStateChange={handleStateChange}
         onPlaying={handlePlaying}
@@ -191,7 +197,7 @@ const Player = React.memo(({
         type="button"
         onClick={onClickMute}
       >
-        {mute ? '음소거 해제' : '음소거'}
+        {isMute ? '음소거 해제' : '음소거'}
       </button>
       <input
         type="range"
@@ -206,6 +212,12 @@ const Player = React.memo(({
         onClick={onClickPlayStyle}
       >
         {playStyles[Number(playStyle)]}
+      </button>
+      <button
+        type="button"
+        onClick={onClickSuffle}
+      >
+        {isSuffle ? '셔플멈추기' : '셔플하기'}
       </button>
     </>
   );

--- a/src/components/__tests__/Player.test.jsx
+++ b/src/components/__tests__/Player.test.jsx
@@ -14,6 +14,7 @@ describe('Player', () => {
   const handleClickMute = jest.fn();
   const handleClickVolume = jest.fn();
   const handleClickPlayStyle = jest.fn();
+  const handleClickSuffle = jest.fn();
 
   function renderPlayer() {
     return render(
@@ -26,6 +27,7 @@ describe('Player', () => {
         onClickMute={handleClickMute}
         onClickVolume={handleClickVolume}
         onClickPlayStyle={handleClickPlayStyle}
+        onClickSuffle={handleClickSuffle}
       />,
     );
   }
@@ -109,5 +111,12 @@ describe('Player', () => {
     fireEvent.click(queryByText('순환 반복'));
 
     expect(handleClickPlayStyle).toBeCalled();
+  });
+
+  it('셔플 버튼을 클릭하면 handleClickSuffle이 실행된다.', () => {
+    const { queryByText } = renderPlayer();
+    fireEvent.click(queryByText('셔플하기'));
+
+    expect(handleClickSuffle).toBeCalled();
   });
 });

--- a/src/container/PlayerContainer.jsx
+++ b/src/container/PlayerContainer.jsx
@@ -10,6 +10,7 @@ import {
   setPreviousMusic,
   changePlayStyle,
   toggleMute,
+  changeSuffle,
   changeVolume,
 } from '../redux/slice';
 
@@ -45,6 +46,10 @@ export default function PlayerContainer() {
     dispatch(changeVolume(volume));
   }, [dispatch]);
 
+  const handleClickSuffle = useCallback(() => {
+    dispatch(changeSuffle());
+  }, [dispatch]);
+
   if (!music?.videoId) {
     return (<></>);
   }
@@ -59,6 +64,7 @@ export default function PlayerContainer() {
       onClickMute={handleClickMute}
       onClickVolume={handleClickVolume}
       onClickPlayStyle={handleClickPlayStyle}
+      onClickSuffle={handleClickSuffle}
     />
   );
 }

--- a/src/container/PlaylistContainer.jsx
+++ b/src/container/PlaylistContainer.jsx
@@ -14,7 +14,8 @@ export default function PlaylistContainer() {
   const playlist = useSelector(get('playlist'));
 
   const handleClickListen = useCallback((music) => {
-    dispatch(setPalyer({ resultToken: 0, ...music }));
+    const resultToken = 0;
+    dispatch(setPalyer({ resultToken, ...music }));
   }, [dispatch, setPalyer]);
 
   const handleClickDelete = useCallback((music) => {

--- a/src/container/SearchResultContainer.jsx
+++ b/src/container/SearchResultContainer.jsx
@@ -4,7 +4,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import SearchResult from '../components/SearchResult';
 
-import { searchMoreMusic, searchMusic, setPalyer } from '../redux/slice';
+import {
+  searchMoreMusic,
+  searchMusic,
+  setPalyer,
+} from '../redux/slice';
 
 import { get } from '../services/utils';
 

--- a/src/container/__tests__/PlayerContainer.test.jsx
+++ b/src/container/__tests__/PlayerContainer.test.jsx
@@ -99,5 +99,13 @@ describe('PlayerContainer', () => {
 
       expect(dispatch).toBeCalled();
     });
+
+    it('셔플버튼을 누르면 dispatch가 실행된다.', () => {
+      const { queryByText } = renderPlayerContainer();
+
+      fireEvent.click(queryByText('셔플하기'));
+
+      expect(dispatch).toBeCalled();
+    });
   });
 });

--- a/src/services/__tests__/utils.test.js
+++ b/src/services/__tests__/utils.test.js
@@ -30,6 +30,14 @@ test('filterMusicInfo', () => {
   expect(filteredMusicInfo.videoId).toBe(music.videoId);
 });
 
+test('filterMusicInfo', () => {
+  const filteredMusicInfo = filterMusicInfo(music);
+
+  expect(filteredMusicInfo.title).toBe(music.title);
+  expect(filteredMusicInfo.url).toBe(music.url);
+  expect(filteredMusicInfo.videoId).toBe(music.videoId);
+});
+
 test('isSameTime', () => {
   expect(isSameTime('1235', 1235)).toBe(true);
   expect(isSameTime('1235.23', 1235.00932)).toBe(true);

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -3,17 +3,21 @@ export function get(key) {
 }
 
 export function filterMusicInfo(music) {
-  const {
-    id: { videoId },
-    snippet: {
-      title,
-      thumbnails: {
-        high: { url },
+  if (music.snippet) {
+    const {
+      id: { videoId },
+      snippet: {
+        title,
+        thumbnails: {
+          high: { url },
+        },
       },
-    },
-  } = music;
+    } = music;
 
-  return ({ videoId, title, url });
+    return ({ videoId, title, url });
+  }
+
+  return music;
 }
 
 export function isSameTime(currentTime, endTime) {
@@ -46,6 +50,19 @@ export function getNextMusic(musics, music) {
   const nextMusic = musics[musicIndex === musics.length - 1 ? 0 : musicIndex + 1];
 
   return filterMusicInfo(nextMusic);
+}
+
+export function suffle(playlist) {
+  const playOrder = [...playlist];
+
+  for (let index = 0; index < playOrder.length; index += 1) {
+    const j = Math.floor(Math.random() * (index + 1));
+    const x = playOrder[index];
+    playOrder[index] = playOrder[j];
+    playOrder[j] = x;
+  }
+
+  return playOrder;
 }
 
 export function translateTime(seconds) {


### PR DESCRIPTION
플레이리스트와 검색 결과를 들을 때 셔플 기능을 추가하였습니다

셔플 방식은 **피셔-예이츠 셔플(Fisher-Yates shuffle) 방식**으로 멜론의 랜덤재생의 방식을 모방해서 만들었습니다 (링크 : https://taesung1993.tistory.com/54)

피셔-예이츠 셔플의 방식을 react의 state와 결합한 대략적 방식은 다음과 같습니다.

1. 사용자가 셔플버튼을 누르면 현재 듣고있는 플레이리스트(or 검색결과)를 섞습니다. 
2. 섞은 플레이리스트를 별도의 state로 유지합니다.
3. 노래가 끝날 때 현재 플레이리스트에 새로추가된 노래가 있는지 확인합니다.
4. 노래가 추가되었다면 다시 플레이리스트를 섞고 그렇지 않다면 섞은 플레이리스트의 다음 노래를 재생합니다.

