### PR TITLE
새로운 검색어인 경우만 검색을 실행하도록 변경

### DIFF
--- a/src/container/SearchResultContainer.jsx
+++ b/src/container/SearchResultContainer.jsx
@@ -15,12 +15,12 @@ import { get } from '../services/utils';
 export default function SearchResultContainer({ keyword }) {
   const dispatch = useDispatch();
 
+  const musics = useSelector(get('musics'));
+  const nextPageToken = useSelector(get('nextPageToken'));
+
   useEffect(() => {
     dispatch(searchMusic(keyword));
   }, [keyword]);
-
-  const musics = useSelector(get('musics'));
-  const nextPageToken = useSelector(get('nextPageToken'));
 
   const handleMoreClick = useCallback(() => {
     dispatch(searchMoreMusic(keyword, nextPageToken));

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -9,6 +9,7 @@ import { getNextMusic, getPreviousMusic, suffle } from '../services/utils';
 const { reducer, actions } = createSlice({
   name: 'application',
   initialState: {
+    previousKeyword: '',
     input: '',
     nextPageToken: '',
     playlist: [],
@@ -23,6 +24,11 @@ const { reducer, actions } = createSlice({
     },
   },
   reducers: {
+    setPreviousKeyword: (state, { payload: previousKeyword }) => ({
+      ...state,
+      previousKeyword,
+    }),
+
     updateInput: (state, { payload: input }) => ({
       ...state,
       input,
@@ -95,6 +101,7 @@ const { reducer, actions } = createSlice({
 });
 
 export const {
+  setPreviousKeyword,
   updateInput,
   setResponse,
   addResponse,
@@ -109,10 +116,16 @@ export const {
 } = actions;
 
 export function searchMusic(keyword) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { previousKeyword } = getState();
+
+    if (previousKeyword === keyword) {
+      return;
+    }
     const response = await fetchYouTubeMusics(keyword);
 
     dispatch(setResponse(response));
+    dispatch(setPreviousKeyword(keyword));
   };
 }
 

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -2,7 +2,10 @@ import thunk from 'redux-thunk';
 
 import configureStore from 'redux-mock-store';
 
+import given from 'given2';
+
 import reducer, {
+  setPreviousKeyword,
   updateInput,
   setResponse,
   addResponse,
@@ -35,6 +38,16 @@ const mockStore = configureStore(middleware);
 
 describe('slice', () => {
   describe('reducer', () => {
+    it('setPreviousKeyword', () => {
+      const initialState = {
+        previousKeyword: '',
+      };
+
+      const state = reducer(initialState, setPreviousKeyword('새로운 음악'));
+
+      expect(state.previousKeyword).toBe('새로운 음악');
+    });
+
     it('updateInput', () => {
       const initialState = {
         input: '',
@@ -174,15 +187,31 @@ describe('slice', () => {
   describe('actions', () => {
     let store;
     describe('searchMusic', () => {
-      beforeEach(() => {
-        store = mockStore({});
+      beforeEach(() => jest.clearAllMocks());
+
+      context('이전 검색어와 같을 때', () => {
+        given('previousKeyword', () => 'DEAN');
+        it('새로운 검색을 시도하지 않는다.', async () => {
+          const storeMock = mockStore({ previousKeyword: 'DEAN' });
+
+          await storeMock.dispatch(searchMusic('DEAN'));
+
+          const actions = storeMock.getActions();
+
+          expect(actions[0]).not.toEqual(setResponse([]));
+        });
       });
+      context('이전 검색어와 다를 때', () => {
+        given('previousKeyword', () => 'LEAN');
+        it('Youtube 음악을 불러와 setMusics를 실행한다.', async () => {
+          const storeMock = mockStore({ previousKeyword: '' });
 
-      it('Youtube 음악을 불러와 setMusics를 실행한다.', async () => {
-        await store.dispatch(searchMusic('DEAN'));
+          await storeMock.dispatch(searchMusic('DEAN'));
 
-        const actions = store.getActions();
-        expect(actions[0]).toEqual(setResponse([]));
+          const actions = storeMock.getActions();
+
+          expect(actions[0]).toEqual(setResponse([]));
+        });
       });
     });
 


### PR DESCRIPTION
플레이리스트에서 기존에 검색했던 검색어를 다시 검색하면 기존에 보여줬던 결과를 보여줌.

ex) BTS검색후 30개의 결과를 봄 -> playlist로 이동 -> 다시 BTS를 검색하면 다시 검색하는 것이 아니라 기존에 30개 결과를 보여줌.