### PR TITLE
 기본 플레이리스트 순서 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,7 +42,7 @@ export default function App() {
   const dispatch = useDispatch();
 
   const playlistMusic = loadItem('PLAYLIST');
-  playlistMusic?.map((music) => dispatch(appendPlaylistMusic(music)));
+  playlistMusic?.reverse()?.map((music) => dispatch(appendPlaylistMusic(music)));
 
   return (
     <>

--- a/src/components/SearchResult.jsx
+++ b/src/components/SearchResult.jsx
@@ -23,7 +23,9 @@ const Results = styled.div({
   width: '720px',
 });
 
-export default function SearchResult({ musics, onMoreClick, onListenClick }) {
+export default function SearchResult({
+  musics, nextPageToken, onMoreClick, onListenClick,
+}) {
   return (
     <>
       <List>
@@ -37,7 +39,7 @@ export default function SearchResult({ musics, onMoreClick, onListenClick }) {
             />
           ))}
         </Results>
-        <SeeMore type="button" onClick={onMoreClick}>See More</SeeMore>
+        {nextPageToken && <SeeMore type="button" onClick={onMoreClick}>See More</SeeMore>}
       </List>
     </>
   );

--- a/src/components/__tests__/SearchResult.test.jsx
+++ b/src/components/__tests__/SearchResult.test.jsx
@@ -19,6 +19,7 @@ describe('SearchResult', () => {
       onMoreClick={handleMoreClick}
       onListenClick={handleListenClick}
       musics={musics.items}
+      nextPageToken="NEXT_PAGE_TOKEN"
     />);
   }
 

--- a/src/container/SearchResultContainer.jsx
+++ b/src/container/SearchResultContainer.jsx
@@ -39,6 +39,7 @@ export default function SearchResultContainer({ keyword }) {
       onMoreClick={handleMoreClick}
       onListenClick={handleListenClick}
       musics={musics}
+      nextPageToken={nextPageToken}
     />
   );
 }

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -4,7 +4,9 @@ import { fetchYouTubeMusics } from '../services/api';
 
 import { saveItem } from '../services/storage';
 
-import { getNextMusic, getPreviousMusic, suffle } from '../services/utils';
+import {
+  check, getNextMusic, getPreviousMusic, suffle,
+} from '../services/utils';
 
 const { reducer, actions } = createSlice({
   name: 'application',
@@ -149,16 +151,19 @@ export function searchMusic(word) {
 
 export function searchMoreMusic(keyword, nextPageToken) {
   return async (dispatch, getState) => {
-    const { previous: { pageToken } } = getState();
+    const { musics, previous: { pageToken } } = getState();
 
     if (pageToken === nextPageToken) {
       return;
     }
+
     dispatch(setPreviousPageToken(nextPageToken));
 
     const response = await fetchYouTubeMusics(keyword, nextPageToken);
 
-    dispatch(addResponse(response));
+    const checkedResponse = check(musics, response);
+
+    dispatch(addResponse(checkedResponse));
   };
 }
 

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -204,7 +204,7 @@ describe('slice', () => {
 
           const actions = storeMock.getActions();
 
-          expect(actions[0]).not.toEqual(setResponse([]));
+          expect(actions[0]).not.toEqual(setResponse({ nextPageToken: 'NEXT_PAGE_TOKEN', items: [] }));
         });
       });
       context('이전 검색어와 다를 때', () => {
@@ -216,7 +216,7 @@ describe('slice', () => {
 
           const actions = storeMock.getActions();
           expect(actions[0]).toEqual(setResponse({ nextPageToken: '', items: [] }));
-          expect(actions[1]).toEqual(setResponse([]));
+          expect(actions[1]).toEqual(setResponse({ nextPageToken: 'NEXT_PAGE_TOKEN', items: [] }));
         });
       });
     });
@@ -224,12 +224,15 @@ describe('slice', () => {
     describe('searchMoreMusic', () => {
       context('연속적인 클릭이 일어나지 않았을 때', () => {
         it('Youtube 음악을 불러와 setMusics를 실행한다.', async () => {
-          store = mockStore({ previous: { pageToken: '' } });
+          store = mockStore({
+            previous: { pageToken: '' },
+            musics: [],
+          });
           await store.dispatch(searchMoreMusic('DEAN', 'NEXT_PAGE_TOKEN'));
 
           const actions = store.getActions();
           expect(actions[0]).toEqual(setPreviousPageToken('NEXT_PAGE_TOKEN'));
-          expect(actions[1]).toEqual(addResponse([]));
+          expect(actions[1]).toEqual(addResponse({ nextPageToken: 'NEXT_PAGE_TOKEN', items: [] }));
         });
       });
 

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -1,5 +1,5 @@
 export function fetchYouTubeMusics() {
-  return [];
+  return { nextPageToken: 'NEXT_PAGE_TOKEN', items: [] };
 }
 
 export function xxx() {

--- a/src/services/__tests__/utils.test.js
+++ b/src/services/__tests__/utils.test.js
@@ -7,6 +7,7 @@ import {
   isSameTime,
   getPreviousMusic,
   getNextMusic,
+  check,
   translateTime,
 } from '../utils';
 
@@ -106,6 +107,10 @@ describe('getNextMusic', () => {
       expect(nextMusic.title).toBe(musics.items[0].snippet.title);
     });
   });
+});
+
+test('check', () => {
+  expect(check(musics.items, musics).items).toHaveLength(0);
 });
 
 test('translateTime', () => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -65,6 +65,14 @@ export function suffle(playlist) {
   return playOrder;
 }
 
+export function check(musics, response) {
+  const filteredMusics = musics.map(({ id: { videoId } }) => videoId);
+  return ({
+    ...response,
+    items: response.items.filter(({ id: { videoId } }) => !filteredMusics.includes(videoId)),
+  });
+}
+
 export function translateTime(seconds) {
   const hour = parseInt(seconds / 3600, 10);
   const min = parseInt((seconds % 3600) / 60, 10);


### PR DESCRIPTION
1. 새로들어왔을 때 localStorage에 있는 음악을 마지막에 추가한 것이 가장 위에 오도록 수정
2. 더이상 불러올 노래가 없으면 SEE MORE 버튼 안보이도록 수정
3. 혹시라도 중복되는 노래가 검색되면 필터링 되도록 수정