### PR TITLE
재생 스타일 수정

### DIFF
--- a/fixtures/playerInfo.js
+++ b/fixtures/playerInfo.js
@@ -1,8 +1,9 @@
 const playerInfo = {
   playStyle: 0,
   volume: 1,
-  mute: false,
-  suffle: false,
+  isMute: false,
+  isSuffle: false,
+  isPaused: false,
 };
 
 export default playerInfo;

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -141,6 +141,7 @@ const Player = React.memo(({
   onClickVolume,
   onClickPlayStyle,
   onClickSuffle,
+  onClickPaused,
 }) => {
   const { videoId, title, url } = music;
   const {
@@ -174,7 +175,8 @@ const Player = React.memo(({
 
   useEffect(() => {
     setState(initialState);
-    player.current.playerInstance?.seekTo(0);
+    onClickPaused(false);
+
     return () => setState(initialState);
   }, [music]);
 
@@ -192,6 +194,7 @@ const Player = React.memo(({
   }, [player, state, playStyle]);
 
   const handleClick = useCallback(() => {
+    onClickPaused();
     setState({
       ...state,
       paused: !paused,

--- a/src/components/__tests__/Player.test.jsx
+++ b/src/components/__tests__/Player.test.jsx
@@ -15,6 +15,7 @@ describe('Player', () => {
   const handleClickVolume = jest.fn();
   const handleClickPlayStyle = jest.fn();
   const handleClickSuffle = jest.fn();
+  const handleClickPaused = jest.fn();
 
   function renderPlayer() {
     return render(
@@ -28,6 +29,7 @@ describe('Player', () => {
         onClickVolume={handleClickVolume}
         onClickPlayStyle={handleClickPlayStyle}
         onClickSuffle={handleClickSuffle}
+        onClickPaused={handleClickPaused}
       />,
     );
   }

--- a/src/container/PlayerContainer.jsx
+++ b/src/container/PlayerContainer.jsx
@@ -14,6 +14,7 @@ import {
   toggleMute,
   changeSuffle,
   changeVolume,
+  togglePaused,
 } from '../redux/slice';
 
 import { get } from '../services/utils';
@@ -72,6 +73,10 @@ export default function PlayerContainer() {
     dispatch(changeSuffle());
   }, [dispatch]);
 
+  const handleTogglePaused = useCallback((paused) => {
+    dispatch(togglePaused(paused));
+  }, [dispatch]);
+
   if (!music?.videoId) {
     return ((
       <EmptyPlayer>
@@ -91,6 +96,7 @@ export default function PlayerContainer() {
       onClickVolume={handleClickVolume}
       onClickPlayStyle={handleClickPlayStyle}
       onClickSuffle={handleClickSuffle}
+      onClickPaused={handleTogglePaused}
     />
   );
 }

--- a/src/container/PlaylistContainer.jsx
+++ b/src/container/PlaylistContainer.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import Playlist from '../components/Playlist';
 
-import { setPalyer, deletePlaylistMusic } from '../redux/slice';
+import { listenMusic, deletePlaylistMusic } from '../redux/slice';
 
 import { get } from '../services/utils';
 
@@ -13,14 +13,14 @@ export default function PlaylistContainer() {
 
   const playlist = useSelector(get('playlist'));
 
-  const handleClickListen = useCallback((music) => {
+  const handleClickListen = useCallback((paused, music) => {
     const resultToken = 0;
-    dispatch(setPalyer({ resultToken, ...music }));
-  }, [dispatch, setPalyer]);
+    dispatch(listenMusic(paused, { resultToken, ...music }));
+  }, [dispatch, listenMusic]);
 
   const handleClickDelete = useCallback((music) => {
     dispatch(deletePlaylistMusic(music));
-  }, [dispatch, setPalyer]);
+  }, [dispatch, deletePlaylistMusic]);
 
   return (
     <Playlist

--- a/src/container/SearchResultContainer.jsx
+++ b/src/container/SearchResultContainer.jsx
@@ -5,9 +5,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import SearchResult from '../components/SearchResult';
 
 import {
+  listenMusic,
   searchMoreMusic,
   searchMusic,
-  setPalyer,
 } from '../redux/slice';
 
 import { get } from '../services/utils';
@@ -29,7 +29,7 @@ export default function SearchResultContainer({ keyword }) {
   const handleListenClick = useCallback(({
     resultToken, videoId, title, url,
   }) => {
-    dispatch(setPalyer({
+    dispatch(listenMusic({
       resultToken, videoId, title, url,
     }));
   }, [dispatch]);

--- a/src/pages/__tests__/PlayerPage.test.jsx
+++ b/src/pages/__tests__/PlayerPage.test.jsx
@@ -2,14 +2,18 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import music from '../../../fixtures/music';
 
 import PlayerPage from '../PlayerPage';
 import playerInfo from '../../../fixtures/playerInfo';
 
+jest.mock('react-redux');
 describe('PlayerPage', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
   useSelector.mockImplementation((selector) => selector({
     player: music,
     playerInfo,

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -5,7 +5,11 @@ import { fetchYouTubeMusics } from '../services/api';
 import { saveItem } from '../services/storage';
 
 import {
-  check, getNextMusic, getPreviousMusic, suffle,
+  check,
+  getNextMusic,
+  getPreviousMusic,
+  suffle,
+  isDifferentMusic,
 } from '../services/utils';
 
 const { reducer, actions } = createSlice({
@@ -26,6 +30,7 @@ const { reducer, actions } = createSlice({
       volume: 1,
       isMute: false,
       isSuffle: false,
+      isPaused: false,
     },
   },
   reducers: {
@@ -104,6 +109,14 @@ const { reducer, actions } = createSlice({
       },
     }),
 
+    togglePaused: (state, { payload: isPaused }) => ({
+      ...state,
+      playerInfo: {
+        ...state.playerInfo,
+        isPaused: isPaused === undefined ? !state.playerInfo.isPaused : isPaused,
+      },
+    }),
+
     updatePlaylistMusic: (state, { payload: playlist }) => ({
       ...state,
       playlist,
@@ -128,6 +141,7 @@ export const {
   toggleMute,
   toggleSuffle,
   changeVolume,
+  togglePaused,
   updatePlaylistMusic,
   appendPlaylistMusic,
 } = actions;
@@ -239,6 +253,22 @@ export function addPlaylistMusic(music) {
     saveItem('PLAYLIST', [music, ...playlist]);
 
     dispatch(appendPlaylistMusic(music));
+  };
+}
+
+export function listenMusic(newPlayer) {
+  return (dispatch, getState) => {
+    const { player: previousPlayer, playerInfo: { isPaused } } = getState();
+
+    if (isDifferentMusic(previousPlayer, newPlayer)) {
+      return dispatch(setPalyer(newPlayer));
+    }
+
+    if (isPaused) {
+      return dispatch(setPalyer(newPlayer));
+    }
+
+    return 0;
   };
 }
 

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -25,6 +25,8 @@ import reducer, {
   addPlaylistMusic,
   deletePlaylistMusic,
   changeSuffle,
+  togglePaused,
+  listenMusic,
 } from './slice';
 
 import music from '../../fixtures/music';
@@ -162,6 +164,24 @@ describe('slice', () => {
 
       const state = reducer(initialState, changeVolume(0.5));
       expect(state.playerInfo.volume).toBe(0.5);
+    });
+
+    it('togglePaused', () => {
+      const initialState = {
+        playerInfo: { isPaused: false },
+      };
+
+      const state = reducer(initialState, togglePaused());
+      expect(state.playerInfo.isPaused).toBe(true);
+    });
+
+    it('togglePaused', () => {
+      const initialState = {
+        playerInfo: { isPaused: false },
+      };
+
+      const state = reducer(initialState, togglePaused(false));
+      expect(state.playerInfo.isPaused).toBe(false);
     });
 
     it('updatePlaylistMusic', () => {
@@ -378,6 +398,45 @@ describe('slice', () => {
           const actions = store.getActions();
           const nextMusic = { resultToken: 0, ...filterMusicInfo(musics.items[1]) };
           expect(actions[0]).toEqual(setPalyer(nextMusic));
+        });
+      });
+    });
+
+    describe('listenMusic', () => {
+      context('새로운 음악의 실행이 요청되었을 때', () => {
+        it('새로운 음악으로 플레이어를 설정한다.', () => {
+          store = mockStore({
+            player: { resultToken: 1, videoId: 'YYY' },
+            playerInfo: { isPaused: false },
+          });
+          store.dispatch(listenMusic({ resultToken: 1, videoId: 'XXX' }));
+          const actions = store.getActions();
+
+          expect(actions[0]).toStrictEqual(setPalyer({ resultToken: 1, videoId: 'XXX' }));
+        });
+      });
+
+      context('기존의 음악이 다시 실행을 요청받을 때', () => {
+        it('멈춰있는 경우라면 다시 플레어어로 설정한다.', () => {
+          store = mockStore({
+            player: { resultToken: 1, videoId: 'YYY' },
+            playerInfo: { isPaused: true },
+          });
+          store.dispatch(listenMusic({ resultToken: 1, videoId: 'YYY' }));
+          const actions = store.getActions();
+
+          expect(actions[0]).toStrictEqual(setPalyer({ resultToken: 1, videoId: 'YYY' }));
+        });
+
+        it('듣고있는 중이라면 무시하다.', () => {
+          store = mockStore({
+            player: { resultToken: 1, videoId: 'YYY' },
+            playerInfo: { isPaused: false },
+          });
+          store.dispatch(listenMusic({ resultToken: 1, videoId: 'YYY' }));
+          const actions = store.getActions();
+
+          expect(actions[0]).toBeUndefined();
         });
       });
     });

--- a/src/services/__tests__/utils.test.js
+++ b/src/services/__tests__/utils.test.js
@@ -10,6 +10,7 @@ import {
   check,
   translateTime,
   isNothing,
+  isDifferentMusic,
 } from '../utils';
 
 test('get', () => {
@@ -44,6 +45,17 @@ test('isSameTime', () => {
   expect(isSameTime('1235', 1235)).toBe(true);
   expect(isSameTime('1235.23', 1235.00932)).toBe(true);
   expect(isSameTime('1233', 1235)).toBe(false);
+});
+
+test('isDifferentMusic', () => {
+  const playerA = { resultToken: 1, videoId: 'XXX' };
+  const playerB = { resultToken: 1, videoId: 'XXX' };
+  const playerC = { resultToken: 0, videoId: 'XXX' };
+  const playerD = { resultToken: 1, videoId: 'XYZ' };
+
+  expect(isDifferentMusic(playerA, playerB)).toBe(false);
+  expect(isDifferentMusic(playerA, playerC)).toBe(true);
+  expect(isDifferentMusic(playerA, playerD)).toBe(true);
 });
 
 describe('getPreviousMusic', () => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -24,6 +24,12 @@ export function isSameTime(currentTime, endTime) {
   return parseInt(Number(currentTime), 10) === parseInt(endTime, 10);
 }
 
+export function isDifferentMusic(previousPlayer, newPlayer) {
+  const { resultToken, videoId } = newPlayer;
+
+  return (previousPlayer.resultToken !== resultToken || previousPlayer.videoId !== videoId);
+}
+
 export function getPreviousMusic(musics, music) {
   if (!musics[0].snippet) {
     const musicIndex = musics.findIndex(({ videoId }) => music.videoId === videoId);


### PR DESCRIPTION
기존에는 듣고 있던 노래를 다시 클릭해도 듣지 못했음.
ex) BTS노래 듣기 -> 멈춤 -> 다시 BTS노래 클릭 -> 아무 변화 없음.

수정이후에는 멈춰있는 경우에만 다시 클릭하면 처음부터 들을 수 있도록 변경
ex) BTS노래 듣기 -> 멈춤 -> 사디 BTS노래 클릭 -> 처음부터 시작.

이 방식이 사용자에게 더 친숙한 방식이라고 생각해서 수정(멜론 플레이어 방식)