### PR TITLE
dropback-filter에서 filter로 사용 변경

### DIFF
--- a/src/container/BackgroundContainer.jsx
+++ b/src/container/BackgroundContainer.jsx
@@ -13,25 +13,29 @@ const BluredBackground = styled.div`
      left: 0;
      right: 0;
      bottom: 0;
-     background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url("${({ url }) => url}");
-     background-position: center;
-     background-repeat: no-repeat;
-     background-size: cover;
-     background-color: #6C8AA3;
+     background-color: black;
      z-index: -1; 
    }
-
-   &:before {
-     content: "";
-     position: absolute;
-     width: 100%;
-     height: 100%;
-     backdrop-filter: blur(40px);
+   & div {
+    position : fixed;
+    top: -50px;
+    left: -50px;
+    right: -50px;
+    bottom: -50px;
+    background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url("${({ url }) => url}");
+    background-position: center;
+    background-size: cover;
+    transform: scale(1.3);
+    filter: blur(25px);
    }
  `;
 
 export default function BackgroundContainer() {
   const { url } = useSelector(get('player'));
 
-  return (<BluredBackground url={url} />);
+  return (
+    <BluredBackground url={url}>
+      <div />
+    </BluredBackground>
+  );
 }


### PR DESCRIPTION
dropback-filter는 테두리까지 깔끔하게 blur를 주지만 아직 버그가 많은 CSS Effect 참고: https://stackoverflow.com/questions/59147858/backdrop-filter-blur-using-google-chrome-on-macos-causes-unwanted-artifacts

따라서 filter를 이용해서 대체함 (2개의 div로 dropback-filter처럼 보이도록 구현)