### PR TITLE
검색결과와 플레이리스트 곡의 갯수가 같을 때 나는 오류 수정

### DIFF
--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -10,6 +10,7 @@ import {
   getPreviousMusic,
   suffle,
   isDifferentMusic,
+  isDifferentPlaylist,
 } from '../services/utils';
 
 const { reducer, actions } = createSlice({
@@ -17,7 +18,7 @@ const { reducer, actions } = createSlice({
   initialState: {
     previous: {
       keyword: null,
-      pageToken: '',
+      pageToken: null,
     },
     input: '',
     nextPageToken: '',
@@ -191,7 +192,7 @@ export function searchMoreMusic(keyword, nextPageToken) {
   };
 }
 
-export function setPreviousMusic(music) {
+export function setPreviousMusic(music, repeat = false) {
   return (dispatch, getState) => {
     const state = getState();
     const {
@@ -204,10 +205,10 @@ export function setPreviousMusic(music) {
     const nowPlaylist = resultToken ? musics : playlist;
 
     if (isSuffle) {
-      if (nowPlaylist.length !== suffledPlaylist.length) {
+      if (isDifferentPlaylist(nowPlaylist, suffledPlaylist) && !repeat) {
         dispatch(sufflePlaylist(resultToken));
 
-        return setPreviousMusic(music);
+        return dispatch(setPreviousMusic(music, !repeat));
       }
       const previousMusic = getPreviousMusic(suffledPlaylist, music);
 
@@ -234,7 +235,7 @@ export function setNextMusic(music, repeat = false) {
     const nowPlaylist = resultToken ? musics : playlist;
 
     if (isSuffle) {
-      if (nowPlaylist.length !== suffledPlaylist.length && !repeat) {
+      if (isDifferentPlaylist(nowPlaylist, suffledPlaylist) && !repeat) {
         dispatch(sufflePlaylist(resultToken));
 
         return dispatch(setNextMusic(music, !repeat));

--- a/src/services/__tests__/utils.test.js
+++ b/src/services/__tests__/utils.test.js
@@ -12,6 +12,7 @@ import {
   isNothing,
   isDifferentMusic,
   isPlaying,
+  isDifferentPlaylist,
 } from '../utils';
 
 test('get', () => {
@@ -40,6 +41,15 @@ test('filterMusicInfo', () => {
   expect(filteredMusicInfo.title).toBe(music.title);
   expect(filteredMusicInfo.url).toBe(music.url);
   expect(filteredMusicInfo.videoId).toBe(music.videoId);
+});
+test('isDifferentPlaylist', () => {
+  const nowPlaylist = musics.items;
+  const suffledPlaylist1 = [musics.items[0]];
+  const suffledPlaylist2 = [...musics.items].reverse().map((item) => filterMusicInfo(item));
+
+  expect(isDifferentPlaylist(nowPlaylist, nowPlaylist)).toBe(false);
+  expect(isDifferentPlaylist(nowPlaylist, suffledPlaylist1)).toBe(true);
+  expect(isDifferentPlaylist(nowPlaylist, suffledPlaylist2)).toBe(true);
 });
 
 test('isSameTime', () => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -20,6 +20,21 @@ export function filterMusicInfo(music) {
   return music;
 }
 
+export function isDifferentPlaylist(nowPlaylist, suffledPlaylist) {
+  if (nowPlaylist.length !== suffledPlaylist.length) {
+    return true;
+  }
+
+  if (!nowPlaylist[0]?.snippet !== !suffledPlaylist[0]?.snippet) {
+    return true;
+  }
+
+  const filteredNow = nowPlaylist.map((music) => filterMusicInfo(music).videoId);
+  const filteredSuffle = suffledPlaylist.map((music) => filterMusicInfo(music).videoId);
+
+  return !!filteredNow.find((videoId) => !filteredSuffle.includes(videoId));
+}
+
 export function isSameTime(currentTime, endTime) {
   return parseInt(Number(currentTime), 10) === parseInt(endTime, 10);
 }
@@ -39,7 +54,7 @@ export function isPlaying(player, videoId) {
 }
 
 export function getPreviousMusic(musics, music) {
-  if (!musics[0].snippet) {
+  if (!musics[0]?.snippet) {
     const musicIndex = musics.findIndex(({ videoId }) => music.videoId === videoId);
     const previousMusic = musics[musicIndex ? musicIndex - 1 : musics.length - 1];
 


### PR DESCRIPTION
현재 플레이리스트를 바탕으로 셔플이 이루어 진 것인지를 확인하는 함수 isSamePlaylist를 생성해서 기존의 단순 길이 비교방식에서 더 정확하게 판단할 수 있도록 구현