### PR TITLE
연속검색이 안되는 경우 수정

### DIFF
--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -18,7 +18,7 @@ const { reducer, actions } = createSlice({
   initialState: {
     previous: {
       keyword: null,
-      pageToken: null,
+      isButtonTouchable: true,
     },
     input: '',
     nextPageToken: '',
@@ -47,11 +47,11 @@ const { reducer, actions } = createSlice({
       },
     }),
 
-    setPreviousPageToken: (state, { payload: pageToken }) => ({
+    setButtonTouchable: (state, { payload: isButtonTouchable }) => ({
       ...state,
       previous: {
         ...state.previous,
-        pageToken,
+        isButtonTouchable,
       },
     }),
 
@@ -141,7 +141,7 @@ const { reducer, actions } = createSlice({
 
 export const {
   setPreviousKeyword,
-  setPreviousPageToken,
+  setButtonTouchable,
   updateInput,
   setResponse,
   addResponse,
@@ -176,19 +176,18 @@ export function searchMusic(word) {
 
 export function searchMoreMusic(keyword, nextPageToken) {
   return async (dispatch, getState) => {
-    const { musics, previous: { pageToken } } = getState();
+    const { musics, previous: { isButtonTouchable } } = getState();
 
-    if (pageToken === nextPageToken) {
-      return;
+    if (isButtonTouchable) {
+      dispatch(setButtonTouchable(false));
+      setTimeout(() => dispatch(setButtonTouchable(true)), 700);
+
+      const response = await fetchYouTubeMusics(keyword, nextPageToken);
+
+      const checkedResponse = check(musics, response);
+
+      dispatch(addResponse(checkedResponse));
     }
-
-    dispatch(setPreviousPageToken(nextPageToken));
-
-    const response = await fetchYouTubeMusics(keyword, nextPageToken);
-
-    const checkedResponse = check(musics, response);
-
-    dispatch(addResponse(checkedResponse));
   };
 }
 

--- a/src/redux/slice.test.js
+++ b/src/redux/slice.test.js
@@ -6,7 +6,7 @@ import given from 'given2';
 
 import reducer, {
   setPreviousKeyword,
-  setPreviousPageToken,
+  setButtonTouchable,
   updateInput,
   setResponse,
   addResponse,
@@ -51,12 +51,12 @@ describe('slice', () => {
       expect(state.previous.keyword).toBe('새로운 음악');
     });
 
-    it('setPreviousPageToken', () => {
-      const initialState = { previous: { pageToken: '' } };
+    it('setButtonTouchable', () => {
+      const initialState = { previous: { isButtonTouchable: true } };
 
-      const state = reducer(initialState, setPreviousPageToken('PREVIOUS_PAGE_TOKEN'));
+      const state = reducer(initialState, setButtonTouchable(false));
 
-      expect(state.previous.pageToken).toBe('PREVIOUS_PAGE_TOKEN');
+      expect(state.previous.isButtonTouchable).toBe(false);
     });
 
     it('updateInput', () => {
@@ -255,20 +255,20 @@ describe('slice', () => {
       context('연속적인 클릭이 일어나지 않았을 때', () => {
         it('Youtube 음악을 불러와 setMusics를 실행한다.', async () => {
           store = mockStore({
-            previous: { pageToken: '' },
+            previous: { isButtonTouchable: true },
             musics: [],
           });
           await store.dispatch(searchMoreMusic('DEAN', 'NEXT_PAGE_TOKEN'));
 
           const actions = store.getActions();
-          expect(actions[0]).toEqual(setPreviousPageToken('NEXT_PAGE_TOKEN'));
+          expect(actions[0]).toEqual(setButtonTouchable(false));
           expect(actions[1]).toEqual(addResponse({ nextPageToken: 'NEXT_PAGE_TOKEN', items: [] }));
         });
       });
 
       context('연속적인 클릭이 일어났을 때', () => {
         it('Youtube 음악을 불러오지 않는다.', async () => {
-          store = mockStore({ previous: { pageToken: 'NEXT_PAGE_TOKEN' } });
+          store = mockStore({ previous: { isButtonTouchable: false } });
           await store.dispatch(searchMoreMusic('DEAN', 'NEXT_PAGE_TOKEN'));
 
           const actions = store.getActions();


### PR DESCRIPTION
API에서 같은 토큰을 주는 경우가 있으므로 기존의 nextPageToken을 기반으로 한 검색 blocking은 사용할 수 없는 경우가 생겼음
연속검색을 setTimeout으로 0.7초 이후에 가능하도록 변경하여 오류 수정